### PR TITLE
Wc 3994 Unique Tree Node Ids

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -63,30 +63,18 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
         var newValue = false;
         //All children selected => select
         if (scope.selectedNodes[scope.orEmpty(selectedNode.type) + selectedNode.code].selectedChildren === selectedNode.children.length) {
-            // if (selected === false) {
-            //     newValue = true;
-            // }
             selected = true;
-
             //No children selected => deselect
         } else if (
             scope.selectedNodes[scope.orEmpty(selectedNode.type) + selectedNode.code].selectedChildren === 0 &&
             selectedNode.children.length > 0
         ) {
-            // if (selected === true) {
-            //     newValue = true;
-            // }
             selected = false;
-
             //Some children selected => deselect
         } else if (
             scope.selectedNodes[scope.orEmpty(selectedNode.type) + selectedNode.code].selectedChildren !== 0 &&
             selectedNode.children.length > 0
         ) {
-            // if (selected === true) {
-            //     newValue = true;
-            // }
-
             selected = false;
         }
 


### PR DESCRIPTION
In the previous implementation the ids were not unique causing an infinite loop in certain circumstances, adding the type as an additional property, if present, to the selectedNodes key map allows the identifier to be unique between our account hierarchy and the users mapped accounts. 